### PR TITLE
return messages with DeployResult

### DIFF
--- a/deployer/deployer.go
+++ b/deployer/deployer.go
@@ -79,6 +79,7 @@ func WithConfirm(confirm bool) DeployOptFunc {
 
 type DeployResult struct {
 	FinalStatus string
+	Messages    []string
 }
 
 // Deploy deploys a stack and returns the final status
@@ -146,6 +147,7 @@ func (b *Deployer) Deploy(ctx context.Context, opts DeployOpts) (*DeployResult, 
 
 	res := DeployResult{
 		FinalStatus: status,
+		Messages:    messages,
 	}
 
 	return &res, nil


### PR DESCRIPTION
### Description 

In case of cloudformation deployment failure, we can use this message to print the reason for failure. 